### PR TITLE
Joyswap

### DIFF
--- a/src/joystick.c
+++ b/src/joystick.c
@@ -121,6 +121,21 @@ static CLOCK joystick_delay;
 static int joykeys[KEYSET_NUM][KEYSET_NUM_KEYS];
 #endif
 
+int swapping = 0;
+
+int getjoyid(int joyport)
+{
+  if (swapping)
+  {
+    if (joyport == 1)
+      joyport = 2;
+    else if (joyport == 2)
+      joyport = 1;
+  }
+
+  return joyport;
+}
+
 /*! \todo SRT: offset is unused! */
 
 static void joystick_latch_matrix(CLOCK offset)
@@ -202,6 +217,7 @@ static void joystick_process_latch(void)
 
 void joystick_set_value_absolute(unsigned int joyport, BYTE value)
 {
+  joyport = getjoyid(joyport);
     if (event_playback_active()) {
         return;
     }
@@ -216,6 +232,7 @@ void joystick_set_value_absolute(unsigned int joyport, BYTE value)
 /* set joystick bits */
 void joystick_set_value_or(unsigned int joyport, BYTE value)
 {
+  joyport = getjoyid(joyport);
     if (event_playback_active()) {
         return;
     }
@@ -233,6 +250,7 @@ void joystick_set_value_or(unsigned int joyport, BYTE value)
 /* release joystick bits */
 void joystick_set_value_and(unsigned int joyport, BYTE value)
 {
+  joyport = getjoyid(joyport);
     if (event_playback_active()) {
         return;
     }
@@ -244,6 +262,7 @@ void joystick_set_value_and(unsigned int joyport, BYTE value)
 
 void joystick_clear(unsigned int joyport)
 {
+  joyport = getjoyid(joyport);
     latch_joystick_value[joyport] = 0;
     latch_joystick_value[0] = (BYTE)joyport;
     joystick_latch_matrix(0);
@@ -257,7 +276,7 @@ void joystick_clear_all(void)
 
 BYTE get_joystick_value(int index)
 {
-    return joystick_value[index];
+    return joystick_value[getjoyid(index)];
 }
 
 /*-----------------------------------------------------------------------*/

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -444,6 +444,24 @@ static void keyboard_restore_released(void)
     restore_raw = 0;
 }
 
+void show_val(int val)
+{
+  int loc = 0x400;  // start of screen mem;
+  char str[256];
+  sprintf(str, "%d", val);
+  for (int k = 0; k < 40; k++)
+  {
+    if (k < strlen(str))
+    {
+      mem_ram[loc+k] = str[k];
+    }
+    else
+    {
+      mem_ram[loc+k] = 32; // insert spaces
+    }
+  }
+}
+
 void keyboard_key_pressed(signed long key)
 {
     int i, latch;
@@ -451,6 +469,9 @@ void keyboard_key_pressed(signed long key)
     if (event_playback_active()) {
         return;
     }
+
+    printf("key = %d\n", (int)key);
+    show_val((int)key);
 
     /* Restore */
     if (((key == key_ctrl_restore1) || (key == key_ctrl_restore2))

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -121,6 +121,7 @@ static int is_left_arrow(int row, int col, int value)
   return (row==7 && col==1 && value!=0);
 }
 
+void debug_msg(int x, int y, char* str);
 extern BYTE mem_ram[];
 extern int swapping;
 static int swap_joyports(void)
@@ -131,6 +132,9 @@ static int swap_joyports(void)
   // I suspect the retro-games branch does not use resource-names
   // like 'JoyDevice*', so I tried this alternate method of
   // swapping the joystick.
+
+  debug_msg(10,10, "JOYSTICK SWAP");
+
   if (swapping == 0) swapping = 1;
   else if (swapping == 1) swapping = 0;
   // mem_ram[0x400+40]++;

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -470,6 +470,18 @@ void show_val(int val)
   }
 }
 
+void show_str(char* str)
+{
+  int k;
+  int loc = 0x400;  // start of screen mem;
+  for (k = 0; k < strlen(str); k++)
+  {
+    if (k < strlen(str))
+    {
+      mem_ram[loc+k] = str[k];
+    }
+  }
+}
 void keyboard_key_pressed(signed long key)
 {
     int i, latch;

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -121,6 +121,7 @@ static int is_left_arrow(int row, int col, int value)
   return (row==7 && col==1 && value!=0);
 }
 
+extern BYTE mem_ram[];
 extern int swapping;
 static int swap_joyports(void)
 {
@@ -132,6 +133,7 @@ static int swap_joyports(void)
   // swapping the joystick.
   if (swapping == 0) swapping = 1;
   else if (swapping == 1) swapping = 0;
+  // mem_ram[0x400+40]++;
 }
 
 static int keyboard_set_latch_keyarr(int row, int col, int value)
@@ -154,6 +156,7 @@ static int keyboard_set_latch_keyarr(int row, int col, int value)
     {
       // do the joystick swap here
       printf("do joystick swap here!!\n");
+      swap_joyports();
     }
 
     return 0;
@@ -444,7 +447,6 @@ static void keyboard_restore_released(void)
     restore_raw = 0;
 }
 
-extern BYTE mem_ram[];
 void show_val(int val)
 {
   int k;
@@ -473,7 +475,7 @@ void keyboard_key_pressed(signed long key)
     }
 
     printf("key = %d\n", (int)key);
-    show_val((int)key);
+    // show_val((int)key);
 
     /* Restore */
     if (((key == key_ctrl_restore1) || (key == key_ctrl_restore2))

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -125,11 +125,11 @@ extern int swapping;
 static int swap_joyports(void)
 {
   // swap joystick ports
-	// I initially tried a technique borrowed from
-	// "ui_joystick2.c" - swap_joystick_ports(), but it didn't work.
-	// I suspect the retro-games branch does not use resource-names
-	// like 'JoyDevice*', so I tried this alternate method of
-	// swapping the joystick.
+  // I initially tried a technique borrowed from
+  // "ui_joystick2.c" - swap_joystick_ports(), but it didn't work.
+  // I suspect the retro-games branch does not use resource-names
+  // like 'JoyDevice*', so I tried this alternate method of
+  // swapping the joystick.
   if (swapping == 0) swapping = 1;
   else if (swapping == 1) swapping = 0;
 }

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -447,10 +447,11 @@ static void keyboard_restore_released(void)
 extern BYTE mem_ram[];
 void show_val(int val)
 {
+  int k;
   int loc = 0x400;  // start of screen mem;
   char str[256];
   sprintf(str, "%d", val);
-  for (int k = 0; k < 40; k++)
+  for (k = 0; k < 40; k++)
   {
     if (k < strlen(str))
     {

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -444,6 +444,7 @@ static void keyboard_restore_released(void)
     restore_raw = 0;
 }
 
+extern BYTE mem_ram[];
 void show_val(int val)
 {
   int loc = 0x400;  // start of screen mem;

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -404,6 +404,7 @@ static void keyboard_restore_released(void)
     restore_raw = 0;
 }
 
+extern int swapping;
 void keyboard_key_pressed(signed long key)
 {
     int i, latch;
@@ -416,6 +417,15 @@ void keyboard_key_pressed(signed long key)
     if (((key == key_ctrl_restore1) || (key == key_ctrl_restore2))
         && machine_has_restore_key())
     {
+        // swap joystick ports
+	// I initially tried a technique borrowed from
+	// "ui_joystick2.c" - swap_joystick_ports(), but it didn't work.
+	// I suspect the retro-games branch does not use resource-names
+	// like 'JoyDevice*', so I tried this alternate method of
+	// swapping the joystick.
+        if (swapping == 0) swapping = 1;
+        else if (swapping == 1) swapping = 0;
+
         keyboard_restore_pressed();
         return;
     }

--- a/src/vicii/vicii.c
+++ b/src/vicii/vicii.c
@@ -491,6 +491,7 @@ void video_canvas_refresh_all(video_canvas_t *canvas);
 
 void debug_msg(int x, int y, char* str)
 {
+
   int i;
   for (i = 0; i < strlen(str); i++)
   {
@@ -500,7 +501,7 @@ void debug_msg(int x, int y, char* str)
   draw_debug();
 
   // trigger pause
-  ui_pause_emulation(1);
+  //ui_pause_emulation(1);
 
   // raster_force_repaint()
   vicii.raster.dont_cache = 1;
@@ -513,7 +514,7 @@ void debug_msg(int x, int y, char* str)
   usleep(1000000);
 
   // un-pause
-  ui_pause_emulation(0);
+  //ui_pause_emulation(0);
 
   // force refresh
   video_canvas_refresh_all(vicii.raster.canvas);

--- a/src/vicii/vicii.c
+++ b/src/vicii/vicii.c
@@ -440,6 +440,8 @@ extern BYTE mem_chargen_rom[0x1000];
 
 BYTE debug_charmem[40*25] = { 0 };
 
+//void show_str(char* str);
+
 void draw_debug(void)
 {
   static int z = 0;
@@ -448,6 +450,7 @@ void draw_debug(void)
   BYTE fontval;
   BYTE* chr_ptr;
   BYTE c;
+  //char str[256];
 
   // TODO: Add my drawing logic here
   width = vicii.raster.geometry->screen_size.width
@@ -458,10 +461,8 @@ void draw_debug(void)
       + vicii.raster.geometry->gfx_position.y * width
       + vicii.raster.geometry->gfx_position.x + vicii.raster.geometry->extra_offscreen_border_left;
 
-  for (x = 0; x < 320; x++)
-  {
-      *(gfx_ptr + x) = 0x02;
-  }
+  //sprintf(str, "%02X %02X %02X %02X", *(gfx_ptr), *(gfx_ptr+1), *(gfx_ptr+2), *(gfx_ptr+3));
+  //show_str(str);
 
   for (y = 0; y < 25; y++)
   {
@@ -487,8 +488,6 @@ void draw_debug(void)
   }
 }
 
-void video_canvas_refresh_all(video_canvas_t *canvas);
-
 void debug_msg(int x, int y, char* str)
 {
 
@@ -500,24 +499,11 @@ void debug_msg(int x, int y, char* str)
 
   draw_debug();
 
-  // trigger pause
-  //ui_pause_emulation(1);
-
-  // raster_force_repaint()
-  vicii.raster.dont_cache = 1;
-  vicii.raster.num_cached_lines = 0;
-
   // force refresh
-  video_canvas_refresh_all(vicii.raster.canvas);
+  vsyncarch_presync(); // does a notify FRAME_DONE
 
   // wait 1 second
   usleep(1000000);
-
-  // un-pause
-  //ui_pause_emulation(0);
-
-  // force refresh
-  video_canvas_refresh_all(vicii.raster.canvas);
 }
 
 /* Reset the VIC-II chip.  */


### PR DESCRIPTION
I'll concede this is a very dirty, unpolished mod that ought to be declined, so my main intent here was just to raise awareness of its existence and what it was trying to achieve.

It created a shortcut-key for CTRL+LeftArrow to swap joystick port 1 and 2.

Here's a video of how it's looking, showing swapping between white fighter and red fighter in IK+:

http://gurce.net/c64mini_files/joyswap_and_msg.mp4

The mod has its shortcomings:
- It doesn't swap the extra buttons on thec64 joystick (just up/down/left/right and fire)
- If the shortcut key is pressed while any joystick is moved to any direction, that direction gets stuck for that joystick. I probably should reset all joystick movement flags to zero upon every switch
- The message text isn't centred, it probably should be

As it is, I think it's in an ok state for the modding community to make use of in their PCU mod. Perhaps little ideas like this can be incubated in that environment to assess the feedback that comes from the community there.

Anyways, no pressure to look at this in any hurry, understand that things are pretty busy there for you guys, and you have your business priorities to focus on, and things like this will be much lower on the priority scale ;)

As for the detailed info and suggestions I got from you guys on the 4-player joystick support, I'll aim to look into that a little later, as a modding buddy, jj, suggested maybe I should aim for lower hanging fruit first, such as this joystick swapping mod. And yeah, I agree, it's been a good opportunity to just get familiar with the VICE source, what's there, what might be possible.

My first attempts at these things are probably going to be crude, dirty, simplistic, non-ideal, but perhaps as experience grows, I could aim for a bit more polish and finesse on these ideas.